### PR TITLE
Speed improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ dnl ============================================================================
 dnl  Compiler stuff.
 
 AS_IF([test "x$enable_flags_setting" = "xyes"], [
-		AX_APPEND_COMPILE_FLAGS([-DHAVE_CONFIG_H -O2 -pipe], [CFLAGS])
+		AX_APPEND_COMPILE_FLAGS([-DHAVE_CONFIG_H -O2 -pipe -DNDEBUG], [CFLAGS])
 
 		AS_CASE([${host_os}],
 			[darwin*], [

--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -903,10 +903,9 @@ sinc_hex_vari_process (SRC_PRIVATE *psrc, SRC_DATA *data)
 static inline void
 calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start_filter_index, int channels, double scale, float * output)
 {	double		fraction, icoeff ;
-	/* The following line is 1999 ISO Standard C. If your compiler complains, get a better compiler. */
 	double		*left, *right ;
 	increment_t	filter_index, max_filter_index ;
-	int			data_index, coeff_count, indx, ch ;
+	int			data_index, coeff_count, indx ;
 
 	left = filter->left_calc ;
 	right = filter->right_calc ;
@@ -929,49 +928,10 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
 		if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
-		{	/*
-			**	Duff's Device.
-			**	See : http://en.wikipedia.org/wiki/Duff's_device
-			*/
-			assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
+		{	assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
 			assert (data_index + channels - 1 < filter->b_end) ;
-			ch = channels ;
-			do
-			{	switch (ch % 8)
-				{	default :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 7 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 6 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 5 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 4 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 3 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 2 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 1 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					} ;
-				}
-			while (ch > 0) ;
+			for (int ch = 0; ch < channels; ch++)
+				left [ch] += icoeff * filter->buffer [data_index + ch] ;
 			} ;
 
 		filter_index -= increment ;
@@ -993,88 +953,16 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 		assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
 		assert (data_index + channels - 1 < filter->b_end) ;
-		ch = channels ;
-		do
-		{
-			switch (ch % 8)
-			{	default :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 7 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 6 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 5 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 4 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 3 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 2 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 1 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-				} ;
-			}
-		while (ch > 0) ;
+		for (int ch = 0; ch < channels; ch++)
+			right [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index - channels ;
 		}
 	while (filter_index > MAKE_INCREMENT_T (0)) ;
 
-	ch = channels ;
-	do
-	{
-		switch (ch % 8)
-		{	default :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-				/* Falls through. */
-			case 7 :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-				/* Falls through. */
-			case 6 :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-				/* Falls through. */
-			case 5 :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-				/* Falls through. */
-			case 4 :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-				/* Falls through. */
-			case 3 :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-				/* Falls through. */
-			case 2 :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-				/* Falls through. */
-			case 1 :
-				ch -- ;
-				output [ch] = scale * (left [ch] + right [ch]) ;
-			} ;
-		}
-	while (ch > 0) ;
+	for(int ch = 0; ch < channels; ch++)
+		output [ch] = scale * (left [ch] + right [ch]) ;
 
 	return ;
 } /* calc_output_multi */

--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -453,8 +453,8 @@ calc_output_stereo (SINC_FILTER *filter, increment_t increment, increment_t star
 			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 			assert (data_index >= 0 && data_index + 1 < filter->b_len) ;
 			assert (data_index + 1 < filter->b_end) ;
-			left [0] += icoeff * filter->buffer [data_index] ;
-			left [1] += icoeff * filter->buffer [data_index + 1] ;
+			for (int ch = 0; ch < 2; ch++)
+				left [ch] += icoeff * filter->buffer [data_index + ch] ;
 			} ;
 
 		filter_index -= increment ;
@@ -476,16 +476,16 @@ calc_output_stereo (SINC_FILTER *filter, increment_t increment, increment_t star
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 		assert (data_index >= 0 && data_index + 1 < filter->b_len) ;
 		assert (data_index + 1 < filter->b_end) ;
-		right [0] += icoeff * filter->buffer [data_index] ;
-		right [1] += icoeff * filter->buffer [data_index + 1] ;
+		for (int ch = 0; ch < 2; ch++)
+			right [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index - 2 ;
 		}
 	while (filter_index > MAKE_INCREMENT_T (0)) ;
 
-	output [0] = scale * (left [0] + right [0]) ;
-	output [1] = scale * (left [1] + right [1]) ;
+	for (int ch = 0; ch < 2; ch++)
+		output [ch] = scale * (left [ch] + right [ch]) ;
 } /* calc_output_stereo */
 
 static int
@@ -604,10 +604,8 @@ calc_output_quad (SINC_FILTER *filter, increment_t increment, increment_t start_
 			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 			assert (data_index >= 0 && data_index + 3 < filter->b_len) ;
 			assert (data_index + 3 < filter->b_end) ;
-			left [0] += icoeff * filter->buffer [data_index] ;
-			left [1] += icoeff * filter->buffer [data_index + 1] ;
-			left [2] += icoeff * filter->buffer [data_index + 2] ;
-			left [3] += icoeff * filter->buffer [data_index + 3] ;
+			for (int ch = 0; ch < 4; ch++)
+				left [ch] += icoeff * filter->buffer [data_index + ch] ;
 			} ;
 
 		filter_index -= increment ;
@@ -629,20 +627,17 @@ calc_output_quad (SINC_FILTER *filter, increment_t increment, increment_t start_
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 		assert (data_index >= 0 && data_index + 3 < filter->b_len) ;
 		assert (data_index + 3 < filter->b_end) ;
-		right [0] += icoeff * filter->buffer [data_index] ;
-		right [1] += icoeff * filter->buffer [data_index + 1] ;
-		right [2] += icoeff * filter->buffer [data_index + 2] ;
-		right [3] += icoeff * filter->buffer [data_index + 3] ;
+		for (int ch = 0; ch < 4; ch++)
+			right [ch] += icoeff * filter->buffer [data_index + ch] ;
+
 
 		filter_index -= increment ;
 		data_index = data_index - 4 ;
 		}
 	while (filter_index > MAKE_INCREMENT_T (0)) ;
 
-	output [0] = scale * (left [0] + right [0]) ;
-	output [1] = scale * (left [1] + right [1]) ;
-	output [2] = scale * (left [2] + right [2]) ;
-	output [3] = scale * (left [3] + right [3]) ;
+	for (int ch = 0; ch < 4; ch++)
+		output [ch] = scale * (left [ch] + right [ch]) ;
 } /* calc_output_quad */
 
 static int
@@ -761,12 +756,8 @@ calc_output_hex (SINC_FILTER *filter, increment_t increment, increment_t start_f
 			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 			assert (data_index >= 0 && data_index + 5 < filter->b_len) ;
 			assert (data_index + 5 < filter->b_end) ;
-			left [0] += icoeff * filter->buffer [data_index] ;
-			left [1] += icoeff * filter->buffer [data_index + 1] ;
-			left [2] += icoeff * filter->buffer [data_index + 2] ;
-			left [3] += icoeff * filter->buffer [data_index + 3] ;
-			left [4] += icoeff * filter->buffer [data_index + 4] ;
-			left [5] += icoeff * filter->buffer [data_index + 5] ;
+			for (int ch = 0; ch < 6; ch++)
+				left [ch] += icoeff * filter->buffer [data_index + ch] ;
 			} ;
 
 		filter_index -= increment ;
@@ -788,24 +779,16 @@ calc_output_hex (SINC_FILTER *filter, increment_t increment, increment_t start_f
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 		assert (data_index >= 0 && data_index + 5 < filter->b_len) ;
 		assert (data_index + 5 < filter->b_end) ;
-		right [0] += icoeff * filter->buffer [data_index] ;
-		right [1] += icoeff * filter->buffer [data_index + 1] ;
-		right [2] += icoeff * filter->buffer [data_index + 2] ;
-		right [3] += icoeff * filter->buffer [data_index + 3] ;
-		right [4] += icoeff * filter->buffer [data_index + 4] ;
-		right [5] += icoeff * filter->buffer [data_index + 5] ;
+		for (int ch = 0; ch < 6; ch++)
+			right [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index - 6 ;
 		}
 	while (filter_index > MAKE_INCREMENT_T (0)) ;
 
-	output [0] = scale * (left [0] + right [0]) ;
-	output [1] = scale * (left [1] + right [1]) ;
-	output [2] = scale * (left [2] + right [2]) ;
-	output [3] = scale * (left [3] + right [3]) ;
-	output [4] = scale * (left [4] + right [4]) ;
-	output [5] = scale * (left [5] + right [5]) ;
+	for (int ch = 0; ch < 6; ch++)
+		output [ch] = scale * (left [ch] + right [ch]) ;
 } /* calc_output_hex */
 
 static int

--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -94,6 +94,11 @@ fp_to_double (increment_t x)
 {	return fp_fraction_part (x) * INV_FP_ONE ;
 } /* fp_to_double */
 
+static inline int
+int_div_ceil (int divident, int divisor) /* == (int) ceil ((float) divident / divisor) */
+{	assert (divident >= 0 && divisor > 0) ; /* For positive numbers only */
+	return (divident + (divisor - 1)) / divisor ;
+}
 
 /*----------------------------------------------------------------------------------------
 */
@@ -295,22 +300,26 @@ calc_output_single (SINC_FILTER *filter, increment_t increment, increment_t star
 	filter_index = filter_index + coeff_count * increment ;
 	data_index = filter->b_current - coeff_count ;
 
+	if (data_index < 0) /* Avoid underflow access to filter->buffer. */
+	{	int steps = -data_index ;
+		/* If the assert triggers we would have to take care not to underflow/overflow */
+		assert (steps <= int_div_ceil (filter_index, increment)) ;
+		filter_index -= increment * steps ;
+		data_index += steps ;
+	}
 	left = 0.0 ;
-	do
-	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
-		{	fraction = fp_to_double (filter_index) ;
-			indx = fp_to_int (filter_index) ;
-			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
-			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-			assert (data_index >= 0 && data_index < filter->b_len) ;
-			assert (data_index < filter->b_end) ;
-			left += icoeff * filter->buffer [data_index] ;
-			}  ;
+	while (filter_index >= MAKE_INCREMENT_T (0))
+	{	fraction = fp_to_double (filter_index) ;
+		indx = fp_to_int (filter_index) ;
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
+		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+		assert (data_index >= 0 && data_index < filter->b_len) ;
+		assert (data_index < filter->b_end) ;
+		left += icoeff * filter->buffer [data_index] ;
 
 		filter_index -= increment ;
 		data_index = data_index + 1 ;
-		}
-	while (filter_index >= MAKE_INCREMENT_T (0)) ;
+		} ;
 
 	/* Now apply the right half of the filter. */
 	filter_index = increment - start_filter_index ;
@@ -444,23 +453,27 @@ calc_output_stereo (SINC_FILTER *filter, increment_t increment, increment_t star
 	filter_index = filter_index + coeff_count * increment ;
 	data_index = filter->b_current - filter->channels * coeff_count ;
 
+	if (data_index < 0) /* Avoid underflow access to filter->buffer. */
+	{	int steps = int_div_ceil (-data_index, 2) ;
+		/* If the assert triggers we would have to take care not to underflow/overflow */
+		assert (steps <= int_div_ceil (filter_index, increment)) ;
+		filter_index -= increment * steps ;
+		data_index += steps * 2;
+	}
 	left [0] = left [1] = 0.0 ;
-	do
-	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
-		{	fraction = fp_to_double (filter_index) ;
-			indx = fp_to_int (filter_index) ;
-			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
-			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-			assert (data_index >= 0 && data_index + 1 < filter->b_len) ;
-			assert (data_index + 1 < filter->b_end) ;
-			for (int ch = 0; ch < 2; ch++)
-				left [ch] += icoeff * filter->buffer [data_index + ch] ;
-			} ;
+	while (filter_index >= MAKE_INCREMENT_T (0))
+	{	fraction = fp_to_double (filter_index) ;
+		indx = fp_to_int (filter_index) ;
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
+		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+		assert (data_index >= 0 && data_index + 1 < filter->b_len) ;
+		assert (data_index + 1 < filter->b_end) ;
+		for (int ch = 0; ch < 2; ch++)
+			left [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index + 2 ;
-		}
-	while (filter_index >= MAKE_INCREMENT_T (0)) ;
+		} ;
 
 	/* Now apply the right half of the filter. */
 	filter_index = increment - start_filter_index ;
@@ -595,23 +608,27 @@ calc_output_quad (SINC_FILTER *filter, increment_t increment, increment_t start_
 	filter_index = filter_index + coeff_count * increment ;
 	data_index = filter->b_current - filter->channels * coeff_count ;
 
+	if (data_index < 0) /* Avoid underflow access to filter->buffer. */
+	{	int steps = int_div_ceil (-data_index, 4) ;
+		/* If the assert triggers we would have to take care not to underflow/overflow */
+		assert (steps <= int_div_ceil (filter_index, increment)) ;
+		filter_index -= increment * steps ;
+		data_index += steps * 4;
+	}
 	left [0] = left [1] = left [2] = left [3] = 0.0 ;
-	do
-	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
-		{	fraction = fp_to_double (filter_index) ;
-			indx = fp_to_int (filter_index) ;
-			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
-			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-			assert (data_index >= 0 && data_index + 3 < filter->b_len) ;
-			assert (data_index + 3 < filter->b_end) ;
-			for (int ch = 0; ch < 4; ch++)
-				left [ch] += icoeff * filter->buffer [data_index + ch] ;
-			} ;
+	while (filter_index >= MAKE_INCREMENT_T (0))
+	{	fraction = fp_to_double (filter_index) ;
+		indx = fp_to_int (filter_index) ;
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
+		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+		assert (data_index >= 0 && data_index + 3 < filter->b_len) ;
+		assert (data_index + 3 < filter->b_end) ;
+		for (int ch = 0; ch < 4; ch++)
+			left [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index + 4 ;
-		}
-	while (filter_index >= MAKE_INCREMENT_T (0)) ;
+		} ;
 
 	/* Now apply the right half of the filter. */
 	filter_index = increment - start_filter_index ;
@@ -747,23 +764,27 @@ calc_output_hex (SINC_FILTER *filter, increment_t increment, increment_t start_f
 	filter_index = filter_index + coeff_count * increment ;
 	data_index = filter->b_current - filter->channels * coeff_count ;
 
+	if (data_index < 0) /* Avoid underflow access to filter->buffer. */
+	{	int steps = int_div_ceil (-data_index, 6) ;
+		/* If the assert triggers we would have to take care not to underflow/overflow */
+		assert (steps <= int_div_ceil (filter_index, increment)) ;
+		filter_index -= increment * steps ;
+		data_index += steps * 6;
+	}
 	left [0] = left [1] = left [2] = left [3] = left [4] = left [5] = 0.0 ;
-	do
-	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
-		{	fraction = fp_to_double (filter_index) ;
-			indx = fp_to_int (filter_index) ;
-			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
-			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-			assert (data_index >= 0 && data_index + 5 < filter->b_len) ;
-			assert (data_index + 5 < filter->b_end) ;
-			for (int ch = 0; ch < 6; ch++)
-				left [ch] += icoeff * filter->buffer [data_index + ch] ;
-			} ;
+	while (filter_index >= MAKE_INCREMENT_T (0))
+	{	fraction = fp_to_double (filter_index) ;
+		indx = fp_to_int (filter_index) ;
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
+		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+		assert (data_index >= 0 && data_index + 5 < filter->b_len) ;
+		assert (data_index + 5 < filter->b_end) ;
+		for (int ch = 0; ch < 6; ch++)
+			left [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index + 6 ;
-		}
-	while (filter_index >= MAKE_INCREMENT_T (0)) ;
+		} ;
 
 	/* Now apply the right half of the filter. */
 	filter_index = increment - start_filter_index ;
@@ -902,25 +923,30 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 	filter_index = filter_index + coeff_count * increment ;
 	data_index = filter->b_current - channels * coeff_count ;
 
+	if (data_index < 0) /* Avoid underflow access to filter->buffer. */
+	{	int steps = int_div_ceil (-data_index, channels) ;
+		/* If the assert triggers we would have to take care not to underflow/overflow */
+		assert (steps <= int_div_ceil (filter_index, increment)) ;
+		filter_index -= increment * steps ;
+		data_index += steps * channels ;
+	}
+
 	memset (left, 0, sizeof (left [0]) * channels) ;
 
-	do
+	while (filter_index >= MAKE_INCREMENT_T (0))
 	{	fraction = fp_to_double (filter_index) ;
 		indx = fp_to_int (filter_index) ;
 		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
-		if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
-		{	assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
-			assert (data_index + channels - 1 < filter->b_end) ;
-			for (int ch = 0; ch < channels; ch++)
-				left [ch] += icoeff * filter->buffer [data_index + ch] ;
-			} ;
+		assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
+		assert (data_index + channels - 1 < filter->b_end) ;
+		for (int ch = 0; ch < channels; ch++)
+			left [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index + channels ;
-		}
-	while (filter_index >= MAKE_INCREMENT_T (0)) ;
+		} ;
 
 	/* Now apply the right half of the filter. */
 	filter_index = increment - start_filter_index ;

--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -6,6 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -299,9 +300,10 @@ calc_output_single (SINC_FILTER *filter, increment_t increment, increment_t star
 	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
 		{	fraction = fp_to_double (filter_index) ;
 			indx = fp_to_int (filter_index) ;
-
+			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+			assert (data_index >= 0 && data_index < filter->b_len) ;
+			assert (data_index < filter->b_end) ;
 			left += icoeff * filter->buffer [data_index] ;
 			}  ;
 
@@ -320,9 +322,10 @@ calc_output_single (SINC_FILTER *filter, increment_t increment, increment_t star
 	do
 	{	fraction = fp_to_double (filter_index) ;
 		indx = fp_to_int (filter_index) ;
-
+		assert (indx < filter->coeff_half_len + 2) ;
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+		assert (data_index >= 0 && data_index < filter->b_len) ;
+		assert (data_index < filter->b_end) ;
 		right += icoeff * filter->buffer [data_index] ;
 
 		filter_index -= increment ;
@@ -446,9 +449,10 @@ calc_output_stereo (SINC_FILTER *filter, increment_t increment, increment_t star
 	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
 		{	fraction = fp_to_double (filter_index) ;
 			indx = fp_to_int (filter_index) ;
-
+			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+			assert (data_index >= 0 && data_index + 1 < filter->b_len) ;
+			assert (data_index + 1 < filter->b_end) ;
 			left [0] += icoeff * filter->buffer [data_index] ;
 			left [1] += icoeff * filter->buffer [data_index + 1] ;
 			} ;
@@ -468,9 +472,10 @@ calc_output_stereo (SINC_FILTER *filter, increment_t increment, increment_t star
 	do
 	{	fraction = fp_to_double (filter_index) ;
 		indx = fp_to_int (filter_index) ;
-
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+		assert (data_index >= 0 && data_index + 1 < filter->b_len) ;
+		assert (data_index + 1 < filter->b_end) ;
 		right [0] += icoeff * filter->buffer [data_index] ;
 		right [1] += icoeff * filter->buffer [data_index + 1] ;
 
@@ -595,9 +600,10 @@ calc_output_quad (SINC_FILTER *filter, increment_t increment, increment_t start_
 	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
 		{	fraction = fp_to_double (filter_index) ;
 			indx = fp_to_int (filter_index) ;
-
+			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+			assert (data_index >= 0 && data_index + 3 < filter->b_len) ;
+			assert (data_index + 3 < filter->b_end) ;
 			left [0] += icoeff * filter->buffer [data_index] ;
 			left [1] += icoeff * filter->buffer [data_index + 1] ;
 			left [2] += icoeff * filter->buffer [data_index + 2] ;
@@ -619,9 +625,10 @@ calc_output_quad (SINC_FILTER *filter, increment_t increment, increment_t start_
 	do
 	{	fraction = fp_to_double (filter_index) ;
 		indx = fp_to_int (filter_index) ;
-
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+		assert (data_index >= 0 && data_index + 3 < filter->b_len) ;
+		assert (data_index + 3 < filter->b_end) ;
 		right [0] += icoeff * filter->buffer [data_index] ;
 		right [1] += icoeff * filter->buffer [data_index + 1] ;
 		right [2] += icoeff * filter->buffer [data_index + 2] ;
@@ -750,9 +757,10 @@ calc_output_hex (SINC_FILTER *filter, increment_t increment, increment_t start_f
 	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
 		{	fraction = fp_to_double (filter_index) ;
 			indx = fp_to_int (filter_index) ;
-
+			assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+			assert (data_index >= 0 && data_index + 5 < filter->b_len) ;
+			assert (data_index + 5 < filter->b_end) ;
 			left [0] += icoeff * filter->buffer [data_index] ;
 			left [1] += icoeff * filter->buffer [data_index + 1] ;
 			left [2] += icoeff * filter->buffer [data_index + 2] ;
@@ -776,9 +784,10 @@ calc_output_hex (SINC_FILTER *filter, increment_t increment, increment_t start_f
 	do
 	{	fraction = fp_to_double (filter_index) ;
 		indx = fp_to_int (filter_index) ;
-
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+		assert (data_index >= 0 && data_index + 5 < filter->b_len) ;
+		assert (data_index + 5 < filter->b_end) ;
 		right [0] += icoeff * filter->buffer [data_index] ;
 		right [1] += icoeff * filter->buffer [data_index + 1] ;
 		right [2] += icoeff * filter->buffer [data_index + 2] ;
@@ -916,7 +925,7 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 	do
 	{	fraction = fp_to_double (filter_index) ;
 		indx = fp_to_int (filter_index) ;
-
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
 		if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
@@ -924,6 +933,8 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 			**	Duff's Device.
 			**	See : http://en.wikipedia.org/wiki/Duff's_device
 			*/
+			assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
+			assert (data_index + channels - 1 < filter->b_end) ;
 			ch = channels ;
 			do
 			{	switch (ch % 8)
@@ -978,9 +989,10 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 	do
 	{	fraction = fp_to_double (filter_index) ;
 		indx = fp_to_int (filter_index) ;
-
+		assert (indx >= 0 && indx + 1 < filter->coeff_half_len + 2) ;
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
-
+		assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
+		assert (data_index + channels - 1 < filter->b_end) ;
 		ch = channels ;
 		do
 		{


### PR DESCRIPTION
In #82 I noticed that 'Duff's device' for manually unrolled loops is wrongly implemented leading to a heavy degradation in speed. Additionally compilers are so good in optimizing that manually unrolled loops are often slower than compiler optimized ones. See https://github.com/erikd/libsamplerate/pull/82#discussion_r312931906 and Benchmark at http://quick-bench.com/znRud0mQhKSWDhgJns_5eYP8_wk

Additionally the fix for #5 in https://github.com/erikd/libsamplerate/commit/c10c8191f21dd12c1bea2d9b9a68536f7cb0491c introduced an `if` in one of the main worker loops although that can be easily moved out with same semantic.

Changes in this PR:
- Add assertions to check for valid indices (optimized out in release builds, so no speed penalty there. Very useful for tests in cases ASAN cannot find or is not used) before changing anything
- Test more channels in `multichan_throughput_test --best-of <n>` and make its output easier parseable
- Replace manually unrolled loops (especially the buggy Duff's device) with regular loops
- Move the `if(data_index < 0)` handling out of the loop (which requires a change from `do-while` to `while` or something like a GOTO)

Measured performance difference on 2 machines. Speedup is up to 2.2x for the loop-transformation and 1.2x for the if-moving for `--best-of 5`. Got some spurious slow-downs though in  the 5%  range which disappeared when running the test again. So probably some kernel-interupt or so.

Graphs:
![bench1](https://user-images.githubusercontent.com/309017/63778094-80c4f180-c8e4-11e9-8e42-6c6e68e75499.png)
![bench2](https://user-images.githubusercontent.com/309017/63778095-80c4f180-c8e4-11e9-9f4b-1f52a7448ab2.png)
![bench3](https://user-images.githubusercontent.com/309017/63778097-80c4f180-c8e4-11e9-970f-52a2f93aaae5.png)
![bench4](https://user-images.githubusercontent.com/309017/63778099-815d8800-c8e4-11e9-93f6-4df2c0a94e2a.png)
