### PR TITLE
Fix CMake warning about case mismatch of sndfile

### DIFF
--- a/cmake/FindSndfile.cmake
+++ b/cmake/FindSndfile.cmake
@@ -13,6 +13,6 @@ find_library(SNDFILE_LIBRARY NAMES sndfile
     HINTS $ENV{SNDFILE_ROOT}/lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SNDFILE DEFAULT_MSG SNDFILE_LIBRARY SNDFILE_INCLUDE_DIR)
+find_package_handle_standard_args(Sndfile DEFAULT_MSG SNDFILE_LIBRARY SNDFILE_INCLUDE_DIR)
 
 mark_as_advanced(SNDFILE_LIBRARY SNDFILE_INCLUDE_DIR)


### PR DESCRIPTION
CMake expects that the file/package name matches in casing. I.e. `find_package(Sndfile)` with a file `FindSndfile` needs `find_package_handle_standard_args(Sndfile ...`

The warning fixed is:

```
CMake Warning (dev) at C:/Program Files/CMake/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
  The package name passed to `find_package_handle_standard_args` (SNDFILE)
  does not match the name of the calling package (Sndfile).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
```