### PR TITLE
Add NDEBUG in autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ dnl ============================================================================
 dnl  Compiler stuff.
 
 AS_IF([test "x$enable_flags_setting" = "xyes"], [
-		AX_APPEND_COMPILE_FLAGS([-DHAVE_CONFIG_H -O2 -pipe], [CFLAGS])
+		AX_APPEND_COMPILE_FLAGS([-DHAVE_CONFIG_H -O2 -pipe -DNDEBUG], [CFLAGS])
 
 		AS_CASE([${host_os}],
 			[darwin*], [


### PR DESCRIPTION
Defining this macro disables all assertions. Added when -O2 is added.

> And how about [this macro](https://www.gnu.org/software/autoconf-archive/ax_check_enable_debug.html)?

This looks good, but tested it on my recent system (Linux Mint 20) it is not supported in the system autoconf (2.69). So I'd avoid that for now.