### PR TITLE
Replace buggy implementationg of Duffs device by regular loop

### DIFF
--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -906,7 +906,7 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 	/* The following line is 1999 ISO Standard C. If your compiler complains, get a better compiler. */
 	double		*left, *right ;
 	increment_t	filter_index, max_filter_index ;
-	int			data_index, coeff_count, indx, ch ;
+	int			data_index, coeff_count, indx ;
 
 	left = filter->left_calc ;
 	right = filter->right_calc ;
@@ -929,49 +929,10 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
 		if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
-		{	/*
-			**	Duff's Device.
-			**	See : http://en.wikipedia.org/wiki/Duff's_device
-			*/
-			assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
+		{	assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
 			assert (data_index + channels - 1 < filter->b_end) ;
-			ch = channels ;
-			do
-			{	switch (ch % 8)
-				{	default :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 7 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 6 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 5 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 4 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 3 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 2 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-						/* Falls through. */
-					case 1 :
-						ch -- ;
-						left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					} ;
-				}
-			while (ch > 0) ;
+			for (int ch = 0; ch < channels; ch++)
+				left [ch] += icoeff * filter->buffer [data_index + ch] ;
 			} ;
 
 		filter_index -= increment ;
@@ -993,88 +954,16 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 		assert (data_index >= 0 && data_index + channels - 1 < filter->b_len) ;
 		assert (data_index + channels - 1 < filter->b_end) ;
-		ch = channels ;
-		do
-		{
-			switch (ch % 8)
-			{	default :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 7 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 6 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 5 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 4 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 3 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 2 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 1 :
-					ch -- ;
-					right [ch] += icoeff * filter->buffer [data_index + ch] ;
-				} ;
-			}
-		while (ch > 0) ;
+		for (int ch = 0; ch < channels; ch++)
+			right [ch] += icoeff * filter->buffer [data_index + ch] ;
 
 		filter_index -= increment ;
 		data_index = data_index - channels ;
 		}
 	while (filter_index > MAKE_INCREMENT_T (0)) ;
 
-	ch = channels ;
-	do
-	{
-		switch (ch % 8)
-		{	default :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-				/* Falls through. */
-			case 7 :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-				/* Falls through. */
-			case 6 :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-				/* Falls through. */
-			case 5 :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-				/* Falls through. */
-			case 4 :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-				/* Falls through. */
-			case 3 :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-				/* Falls through. */
-			case 2 :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-				/* Falls through. */
-			case 1 :
-				ch -- ;
-				output [ch] = (float) (scale * (left [ch] + right [ch])) ;
-			} ;
-		}
-	while (ch > 0) ;
+	for(int ch = 0; ch < channels; ch++)
+		output [ch] = (float) (scale * (left [ch] + right [ch])) ;
 
 	return ;
 } /* calc_output_multi */


### PR DESCRIPTION
Duffs device would have required to put the `switch` outside the loop
However using a regular loop modern-ish compilers produce faster code resulting in up to 2x speedup

See #94 for measurements 

Reasons for the better code:
- No modulo operation in every loop (costly)
- Access in increasing, linear order instead of backwards access allows better use of cache
- Compiler can detect the structure and e.g. issue prefetch instructions

And finally: The code is much shorter and more readable