### PR TITLE
add NuttX OS build hooks

### DIFF
--- a/NuttX/Kconfig
+++ b/NuttX/Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config AUDIO_SRC
+       bool "Audio Samplerate Convertor Library"
+       default n
+       ---help---
+               Enable build for various SRC functions
+
+if AUDIO_SRC
+
+endif # LIBSRC

--- a/NuttX/Make.defs
+++ b/NuttX/Make.defs
@@ -1,0 +1,31 @@
+############################################################################
+# audio/libsamplerate/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_AUDIO_SRC),y)
+CSRCS += samplerate.c
+CSRCS += src_sinc.c
+CSRCS += src_linear.c
+CSRCS += src_zoh.c
+
+VPATH += libsamplerate/src
+SUBDIRS += libsamplerate/src
+DEPPATH += --dep-path libsamplerate/src
+
+endif


### PR DESCRIPTION
Add the needed hooks for the NuttX OS build system.
NuttX OS uses Kconfig to set the needed configuration options.

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>