### PR TITLE
Fix README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is libsamplerate, `0.1.9`.
 libsamplerate (also known as Secret Rabbit Code) is a library for performing sample rate conversion of audio data.
 
 * The [`src/`](https://github.com/libsndfile/libsamplerate/tree/master/src) directory contains the source code for library itself.
-* The [`doc/`](https://github.com/libsndfile/libsamplerate/tree/master/doc) directory contains the libsamplerate documentation.
+* The [`docs/`](https://github.com/libsndfile/libsamplerate/tree/master/docs) directory contains the libsamplerate documentation.
 * The [`examples/`](https://github.com/libsndfile/libsamplerate/tree/master/examples) directory contains examples of how to write code using libsamplerate.
 * The [`tests/`](https://github.com/libsndfile/libsamplerate/tree/master/tests) directory contains programs which link against libsamplerate and test its functionality.
 * The [`Win32/`](https://github.com/libsndfile/libsamplerate/tree/master/Win32) directory contains files and documentation to allow libsamplerate to compile under Win32 with the Microsoft Visual C++ compiler.
@@ -29,7 +29,7 @@ Branches [actively built](https://github.com/libsndfile/libsamplerate/actions) b
 
 ## Win32
 
-There are detailed instructions for building libsamplerate on Win32 in the file [`doc/win32.html`](http://libsndfile.github.io/libsamplerate/win32.html).
+There are detailed instructions for building libsamplerate on Win32 in the file [`docs/win32.md`](https://github.com/libsndfile/libsamplerate/tree/master/docs/win32.md).
 
 ## macOS
 

--- a/docs/api_full.md
+++ b/docs/api_full.md
@@ -137,7 +137,7 @@ When using the **src_process** or **src_callback_process** APIs and updating the
 smoothly transition between the conversion ratio of the last call and the
 conversion ratio of the current call.
 
-If the user want to bypass this smooth transition and achieve a step response in
+If the user wants to bypass this smooth transition and achieve a step response in
 the conversion ratio, the **src_set_ratio** function can be used to set the
 starting conversion ratio of the next call to **src_process** or
 **src_callback_process**.

--- a/docs/api_misc.md
+++ b/docs/api_misc.md
@@ -8,7 +8,7 @@ layout: default
 
 Most of the API functions either return an integer error (ie **src_simple** and
 **src_process**) or return an integer error value via an int pointer parameter
-(**src_new**). These integer error values can be converted into a human readable
+(**src_new**). These integer error values can be converted into human-readable
 text strings by calling the function:
 
 ```c
@@ -36,7 +36,7 @@ enum
 } ;
 ```
 
-As new converters are added, they will given a number corresponding to the next
+As new converters are added, they will be given a number corresponding to the next
 integer.
 
 The details of these converters are as follows:
@@ -46,7 +46,7 @@ The details of these converters are as follows:
   converter, providing a worst case Signal-to-Noise Ratio (SNR) of 97 decibels
   (dB) at a bandwidth of 97%. All three SRC_SINC_* converters are based on the
   techniques of [Julius O. Smith](http://ccrma.stanford.edu/~jos/resample/)
-  although this code was developed independantly.
+  although this code was developed independently.
 - **SRC_SINC_MEDIUM_QUALITY** - This is another bandlimited interpolator much
   like the previous one. It has an SNR of 97dB and a bandwidth of 90%. The speed
   of the conversion is much faster than the previous one.
@@ -98,14 +98,14 @@ typedef struct
 
 The **data_in** pointer is used to pass audio data into the converter while the
 **data_out** pointer supplies the converter with an array to hold the
-converter's output. For a converter which has been configured for mulitchannel
+converter's output. For a converter which has been configured for multichannel
 operation, these pointers need to point to a single array of interleaved data.
 
 The **input_frames** and **output_frames** fields supply the converter with the
 lengths of the arrays (in frames) pointed to by the **data_in** and **data_out**
-pointers respectively. For monophinc data, these values would indicate the
+pointers respectively. For monophonic data, these values would indicate the
 length of the arrays while for multi channel data these values would be equal to
-the the length of the array divided by the number of channels.
+the length of the array divided by the number of channels.
 
 The **end_of_input** field is only used when the sample rate converter is used
 by calling the **src_process** function. In this case it should be set to zero
@@ -114,7 +114,7 @@ the last.
 
 Finally, the **src_ratio** field specifies the conversion ratio defined as the
 output sample rate divided by the input sample rate. For a connected set of
-buffers, this value can be varies on each call to **src_process** resulting in a
+buffers, this value can vary on each call to **src_process** resulting in a
 time varying sample rate conversion process. For time varying sample rate
 conversions, the ratio will be linearly interpolated between the **src_ratio**
 value of the previous call to **src_process** and the value for the current


### PR DESCRIPTION
Fixes some typos in [README.md](https://github.com/libsndfile/libsamplerate/blob/master/README.md) and docs.