### PR TITLE
autofoo and examples/audio_out update:

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 
 DISTCHECK_CONFIGURE_FLAGS = --enable-werror
 
-AM_CPPFLAGS = -I$(top_srcdir)/include $(OS_SPECIFIC_INCLUDES)
+AM_CPPFLAGS = -I$(top_srcdir)/include
 
 EXTRA_DIST = autogen.sh libsamplerate.spec.in samplerate.pc.in Make.bat Win32 \
     Octave/generate_filter.m Octave/make_filter.m Octave/measure_filter.m \
@@ -60,17 +60,15 @@ dist_doc_DATA = docs/SRC.png docs/SRC.css docs/index.md docs/license.md docs/his
 #############
 
 if HAVE_LIBSNDFILE
-if HAVE_LIBALSA
 noinst_PROGRAMS = examples/varispeed-play examples/timewarp-file
 
 examples_varispeed_play_SOURCES = examples/varispeed-play.c examples/audio_out.c examples/audio_out.h
-examples_varispeed_play_CFLAGS = $(SNDFILE_CFLAGS) $(ALSA_CFLAGS)
-examples_varispeed_play_LDADD = src/libsamplerate.la $(SNDFILE_LIBS) $(ALSA_LIBS) $(OS_SPECIFIC_LINKS)
+examples_varispeed_play_CFLAGS = $(SNDFILE_CFLAGS) $(AUDIO_CFLAGS)
+examples_varispeed_play_LDADD = src/libsamplerate.la $(SNDFILE_LIBS) $(AUDIO_LIBS)
 
 examples_timewarp_file_SOURCES = examples/timewarp-file.c
-examples_timewarp_file_CFLAGS = $(SNDFILE_CFLAGS) $(ALSA_CFLAGS)
-examples_timewarp_file_LDADD = src/libsamplerate.la $(SNDFILE_LIBS) $(ALSA_LIBS)
-endif
+examples_timewarp_file_CFLAGS = $(SNDFILE_CFLAGS)
+examples_timewarp_file_LDADD = src/libsamplerate.la $(SNDFILE_LIBS)
 endif
 
 ##########

--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,6 @@ AS_IF([test "x$enable_alsa" != "xno"], [
 					])
 			])
 	])
-AM_CONDITIONAL([HAVE_LIBALSA], [test "x$enable_alsa" = "xyes"])
 
 dnl ====================================================================================
 dnl  Check for libfftw3 which is required for the test and example programs.
@@ -278,22 +277,25 @@ AS_IF([test "x$ax_cv_c_compiler_vendor" = "xgnu"], [
 	])
 
 dnl ====================================================================================
-dnl  Find known host OS.
+dnl  Find known host OS, set OS-specific audio-out flags.
 
-OS_SPECIFIC_INCLUDES=""
 os_is_win32=0
 
+AUDIO_CFLAGS=""
+AUDIO_LIBS=""
+
 AS_CASE([${host_os}],
-	[darwin* | rhapsody*], [
-		OS_SPECIFIC_INCLUDES="-fpascal-strings -I/Developer/Headers/FlatCarbon"
-		OS_SPECIFIC_LINKS="-framework CoreAudio"],
+	[darwin*], [dnl this requires 10.5+
+		AUDIO_LIBS="-framework CoreAudio"],
 	[mingw32*], [
-		OS_SPECIFIC_LINKS="-lwinmm"
+		AUDIO_LIBS="-lwinmm"
 		os_is_win32=1],
-	[
-		OS_SPECIFIC_INCLUDES=""
-		OS_SPECIFIC_LINKS=""
-	])
+	[linux*], [dnl have OSS as fallback if no ALSA
+		AS_IF([test "x$enable_alsa" = "xyes"], [
+			AUDIO_LIBS="$ALSA_LIBS"
+			AUDIO_CFLAGS="$ALSA_CFLAGS"
+		])],
+	[])
 
 dnl ====================================================================================
 dnl  Now use the information from the checking stage.
@@ -302,8 +304,8 @@ AC_DEFINE_UNQUOTED([OS_IS_WIN32], [${os_is_win32}], [Set to 1 if compiling for W
 
 AC_SUBST(SHLIB_VERSION_ARG)
 AC_SUBST(SHARED_VERSION_INFO)
-AC_SUBST(OS_SPECIFIC_INCLUDES)
-AC_SUBST(OS_SPECIFIC_LINKS)
+AC_SUBST(AUDIO_CFLAGS)
+AC_SUBST(AUDIO_LIBS)
 
 AC_CONFIG_FILES([
 		Makefile

--- a/examples/audio_out.c
+++ b/examples/audio_out.c
@@ -23,13 +23,6 @@
 
 #include "audio_out.h"
 
-#if HAVE_ALSA
-	#define ALSA_PCM_NEW_HW_PARAMS_API
-	#define ALSA_PCM_NEW_SW_PARAMS_API
-	#include <alsa/asoundlib.h>
-	#include <sys/time.h>
-#endif
-
 #if (HAVE_SNDFILE)
 
 #include <math.h>
@@ -48,6 +41,12 @@
 #if defined (__linux__)
 
 #if HAVE_ALSA
+
+#define ALSA_PCM_NEW_HW_PARAMS_API
+#define ALSA_PCM_NEW_SW_PARAMS_API
+
+#include <alsa/asoundlib.h>
+#include <sys/time.h>
 
 #define	ALSA_MAGIC		MAKE_MAGIC ('L', 'n', 'x', '-', 'A', 'L', 'S', 'A')
 
@@ -547,7 +546,7 @@ macosx_open (int channels, int samplerate)
 		return NULL ;
 		} ;
 
-	return (MACOSX_AUDIO_OUT *) macosx_out ;
+	return (AUDIO_OUT *) macosx_out ;
 } /* macosx_open */
 
 static void
@@ -614,8 +613,15 @@ macosx_audio_out_callback (AudioDeviceID device, const AudioTimeStamp* current_t
 	const AudioBufferList* data_in, const AudioTimeStamp* time_in,
 	AudioBufferList* data_out, const AudioTimeStamp* time_out, void* client_data)
 {	MACOSX_AUDIO_OUT	*macosx_out ;
-	int		k, size, frame_count, read_count ;
+	int		size, frame_count, read_count ;
 	float	*buffer ;
+
+	/* unused params: */
+	(void) device;
+	(void) current_time;
+	(void) data_in;
+	(void) time_in;
+	(void) time_out;
 
 	if ((macosx_out = (MACOSX_AUDIO_OUT*) client_data) == NULL)
 	{	printf ("macosx_play : AUDIO_OUT is NULL.\n") ;


### PR DESCRIPTION
- configure.ac:
  - remove HAVE_LIBALSA AM_CONDITIONAL.
  - os-specifically set AUDIO_CFLAGS and AUDIO_LIBS matching audio_out.c
    which enables mingw and darwin builds of example programs.
  - remove unnecessary -fpascal-strings -I/Developer/Headers/FlatCarbon
    from darwin-specific flags.
  - remove OS_SPECIFIC_INCLUDES and OS_SPECIFIC_LINKS.
  - remove another rhapsody* test which should be irrelevant these days.

- Makefile.am:
  - replace unconditional ALSA_CFLAGS and ALSA_LIBS with AUDIO_CFLAGS
    and AUDIO_LIBS.
  - remove unnecessary ALSA_CFLAGS and ALSA_LIBS from timewarp_file build
  - remove OS_SPECIFIC_INCLUDES and OS_SPECIFIC_LINKS.

- examples/audio_out.c:
  - move ALSA defines and includes down to where they belong.
  - Mac OS X CoreAudio warning fixes.