### PR TITLE
CMake: install CMake export files to consistent location on each OS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,11 +115,7 @@ if(LIBSAMPLERATE_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/samplerate.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
   endif()
 
-  if(WIN32 AND (NOT MINGW) AND (NOT CYGWIN))
-    set(CMAKE_INSTALL_PACKAGEDIR cmake) 
-  else()
-    set(CMAKE_INSTALL_PACKAGEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/SampleRate)
-  endif()
+  set(CMAKE_INSTALL_PACKAGEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/SampleRate")
 
   configure_package_config_file(../cmake/SampleRateConfig.cmake.in SampleRateConfig.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})


### PR DESCRIPTION
Currently the differing installation locations per OS requires [duplicating the logic](https://github.com/mixxxdj/vcpkg/pull/4/commits/ceb1d02d523a1494ff6786c1811abd3d25e9c8a9#diff-c4f79e9dc3ed66b0a69b0f9bd4d4e7834a9566f83b7c7514c98a62ada1d88637R15) to package libsamplerate in vcpkg.