### PR TITLE
Specify test harness in Automake correctly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,31 +78,26 @@ endif
 # tests/ #
 ##########
 
-check_PROGRAMS = tests/misc_test tests/termination_test tests/simple_test tests/callback_test \
-	tests/reset_test tests/multi_channel_test tests/snr_bw_test tests/float_short_test \
-	tests/varispeed_test tests/callback_hang_test tests/src-evaluate tests/throughput_test \
-	tests/multichan_throughput_test tests/downsample_test tests/clone_test tests/nullptr_test
-
-check: $(check_PROGRAMS)
-	date
-	uname -a
-	tests/misc_test
-	tests/termination_test
-	tests/callback_hang_test
-	tests/downsample_test
-	tests/simple_test
-	tests/callback_test
-	tests/reset_test
-	tests/clone_test
-	tests/nullptr_test
-	tests/multi_channel_test
+TESTS = \
+	tests/callback_hang_test \
+	tests/callback_test \
+	tests/clone_test \
+	tests/downsample_test \
+	tests/float_short_test \
+	tests/misc_test \
+	tests/multi_channel_test \
+	tests/nullptr_test \
+	tests/reset_test \
+	tests/simple_test \
+	tests/snr_bw_test \
+	tests/termination_test \
+	tests/throughput_test \
 	tests/varispeed_test
-	tests/float_short_test
-	tests/snr_bw_test
-	tests/throughput_test
-	@echo "-----------------------------------------------------------------"
-	@echo "  ${PACKAGE}-${VERSION} passed all tests."
-	@echo "-----------------------------------------------------------------"
+
+check_PROGRAMS = \
+	$(TESTS) \
+	tests/multichan_throughput_test \
+	tests/src-evaluate
 
 #===============================================================================
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# Copyright (C) 2002-2017 Erik de Castro Lopo (erikd AT mega-nerd DOT com).
+# Copyright (C) 2002-2021 Erik de Castro Lopo (erikd AT mega-nerd DOT com).
 
 dnl Require autoconf version >= 2.69)
 AC_PREREQ([2.69])
@@ -27,7 +27,7 @@ AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([src/config.h])
 
-AM_INIT_AUTOMAKE([1.14 foreign dist-bzip2 no-dist-gzip subdir-objects])
+AM_INIT_AUTOMAKE([1.14 foreign dist-bzip2 no-dist-gzip subdir-objects serial-tests])
 AM_SILENT_RULES([yes])
 
 dnl ====================================================================================


### PR DESCRIPTION
* Previously, `make distcheck` would fail with very high
  values of `-j`, due to a race condition in how the test
  harness was specified. We now use the vanilla (serial)
  testing paradigm recommended by Automake.