### PR TITLE
calculate SHARED_VERSION_INFO from PACKAGE_VERSION

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,10 +73,21 @@ dnl      age.
 dnl   6. If any interfaces have been removed since the last public release, then set age
 dnl      to 0.
 
-CLEAN_VERSION=`echo $PACKAGE_VERSION | $SED "s/p.*//"`
-VERSION_MINOR=`echo $CLEAN_VERSION | $SED "s/.*\.//"`
 
-SHARED_VERSION_INFO="1:$VERSION_MINOR:1"
+dnl https://autotools.io/libtool/version.html#idm46482193960416 (2021-01-22)
+dnl For Linux, for instance, while the last two values map directly from the
+dnl command-line, the first is calculated by subtracting age from current.
+dnl On the other hand, on modern FreeBSD, only one component is used in the
+dnl library version, which corresponds to current.
+
+dnl if PACKAGE_VERSION follows [Semantic Versioning](https://semver.org/)
+dnl of the library, we can use this:
+CLEAN_VERSION=$(echo $PACKAGE_VERSION | $SED "s/p.*//")
+VERSION_MAJOR=$(echo $CLEAN_VERSION   | cut -f1 -d.)
+VERSION_MINOR=$(echo $CLEAN_VERSION   | cut -f2 -d.)
+VERSION_BUGFIX=$(echo $CLEAN_VERSION  | cut -f3 -d.)
+
+SHARED_VERSION_INFO="$((VERSION_MAJOR+VERSION_MINOR)):${VERSION_BUGFIX}:${VERSION_MINOR}"
 
 dnl ====================================================================================
 


### PR DESCRIPTION
this attempts to fix #140.

it assumes that the package-version follows [semantic versioning](https://semver.org) for the library itself.
since the `libsamplerate` project *only* contains the library, i think this is a safe assumption.

as libsamplerate is used in high-profile applications, like [vlc](https://www.videolan.org/), [alsa-utils](https://github.com/alsa-project/alsa-utils) or [ardour](https://ardour.org/), it is therefore one of the most popular audio libraries installed on Linux Desktops (e.g. it lists under the [top 520](https://qa.debian.org/popcon.php?package=libsamplerate) most installed packages on an average Debian installation - that popcon lists is probably mainly driven by servers (that don't have much to do with the typical system that needs to do anything with sound) and the like and includes packages  which are essential to actually boot a system - so i think the popcon is a very conservative estimate on the actual popularity of the library on user Desktops).

as such, i think it is really important to get the library versioning right.


Closes: https://github.com/libsndfile/libsamplerate/issues/140