### PR TITLE
Decouple libtool's -version-info from PACKAGE_VERSION

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,6 @@
-Unreleased
+Version 0.2.1 (2021-01-23)
+  * Fix incorrect passing of -version-info to libtool, causing a
+    regression on versioned file name of the shared library (#140).
 
 Version 0.2.0 (2021-01-21)
   * API:

--- a/configure.ac
+++ b/configure.ac
@@ -72,11 +72,7 @@ dnl   5. If any interfaces have been added since the last public release, then i
 dnl      age.
 dnl   6. If any interfaces have been removed since the last public release, then set age
 dnl      to 0.
-
-CLEAN_VERSION=`echo $PACKAGE_VERSION | $SED "s/p.*//"`
-VERSION_MINOR=`echo $CLEAN_VERSION | $SED "s/.*\.//"`
-
-SHARED_VERSION_INFO="1:$VERSION_MINOR:1"
+SHARED_VERSION_INFO="2:1:2"
 
 dnl ====================================================================================
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -33,3 +33,4 @@ layout: default
 - Version 0.1.8 (Aug 15 2011) Minor bug fixes and updates.
 - Version 0.1.9 (Sep 19 2016) Fix for a segfault. Relicense under BSD license.
 - Version 0.2.0 (Jan 21 2021) Cleaned up build system.
+- Version 0.2.1 (Jan 23 2021) Fix libtool ABI versioning.


### PR DESCRIPTION
* Trying to compute -version-info from PACKAGE_VERSION is a
  recipe for disaster. We will maintain it separately going
  forward.

Fixes: #140