### PR TITLE
exclude repository configuration from the archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+# enforce correct file-extensions
 *.ac text eol=lf
 *.am text eol=lf
 *.m4 text eol=lf
@@ -8,3 +9,7 @@
 *.bat text eol=crlf
 *.def text eol=crlf
 *.msvc text eol=crlf
+
+# repository configuration excluded from the archive
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
this PR excludes repository configuration (like .gitignore, github-workflows and .travis.yml from the archive files (generated via git archive, or when downloading a zip/tar release (resp. snapshot) from github).

reasoning: those file really only make sense in the context of this gitrepository.

speaking with my Debian maintainer hat on:

if some downstream consumer of the source packages (e.g. a linux distribution package) uses git to manage the packaging, they usually have different requirements on how the repository should be configured, so `.gitignore` files that are perfectly fine for upstream development can often be considered harmful in environments that mostly deal with packaging.

similarily, the `.github/` directory **only** makes sense for a repository that is hosted on github.
`git archive` (and thus: github's "export to zipfile") are obviously not intended to be used to popuplate github repositories (use *fork* for that), so the `.github/` directory shouldn't be included.
simililarily for `.travis.yml`, which is currently not used by libsamplerate