### PR TITLE
Hide more private symbols using GCC's visibility support

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2002-2016, Erik de Castro Lopo <erikd@mega-nerd.com>
+** Copyright (c) 2002-2021, Erik de Castro Lopo <erikd@mega-nerd.com>
 ** All rights reserved.
 **
 ** This code is released under 2-clause BSD license. Please see the
@@ -15,6 +15,18 @@
 #endif
 
 #include <math.h>
+
+#if defined (_WIN32) || defined (__CYGWIN__) || defined (__MORPHOS__)
+  #define LIBSAMPLERATE_DLL_PRIVATE
+#else
+  #if __GNUC__ >= 4 /* also works for Clang */
+    #define LIBSAMPLERATE_DLL_PRIVATE __attribute__ ((visibility ("hidden")))
+  #elif defined (__APPLE__)
+    #define LIBSAMPLERATE_DLL_PRIVATE __private_extern__
+  #else
+    #define LIBSAMPLERATE_DLL_PRIVATE
+  #endif
+#endif
 
 #define	SRC_MAX_RATIO			256
 #define	SRC_MAX_RATIO_STR		"256"

--- a/src/src_linear.c
+++ b/src/src_linear.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2002-2016, Erik de Castro Lopo <erikd@mega-nerd.com>
+** Copyright (c) 2002-2021, Erik de Castro Lopo <erikd@mega-nerd.com>
 ** All rights reserved.
 **
 ** This code is released under 2-clause BSD license. Please see the
@@ -155,7 +155,7 @@ linear_vari_process (SRC_STATE *state, SRC_DATA *data)
 /*------------------------------------------------------------------------------
 */
 
-const char*
+LIBSAMPLERATE_DLL_PRIVATE const char*
 linear_get_name (int src_enum)
 {
 	if (src_enum == SRC_LINEAR)
@@ -164,7 +164,7 @@ linear_get_name (int src_enum)
 	return NULL ;
 } /* linear_get_name */
 
-const char*
+LIBSAMPLERATE_DLL_PRIVATE const char*
 linear_get_description (int src_enum)
 {
 	if (src_enum == SRC_LINEAR)
@@ -193,7 +193,7 @@ linear_data_new (int channels)
 	return priv ;
 }
 
-SRC_STATE *
+LIBSAMPLERATE_DLL_PRIVATE SRC_STATE *
 linear_state_new (int channels, SRC_ERROR *error)
 {
 	assert (channels > 0) ;

--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2002-2016, Erik de Castro Lopo <erikd@mega-nerd.com>
+** Copyright (c) 2002-2021, Erik de Castro Lopo <erikd@mega-nerd.com>
 ** All rights reserved.
 **
 ** This code is released under 2-clause BSD license. Please see the
@@ -164,7 +164,7 @@ int_div_ceil (int divident, int divisor) /* == (int) ceil ((float) divident / di
 /*----------------------------------------------------------------------------------------
 */
 
-const char*
+LIBSAMPLERATE_DLL_PRIVATE const char*
 sinc_get_name (int src_enum)
 {
 	switch (src_enum)
@@ -183,7 +183,7 @@ sinc_get_name (int src_enum)
 	return NULL ;
 } /* sinc_get_descrition */
 
-const char*
+LIBSAMPLERATE_DLL_PRIVATE const char*
 sinc_get_description (int src_enum)
 {
 	switch (src_enum)
@@ -257,7 +257,7 @@ sinc_filter_new (int converter_type, int channels)
 	return priv ;
 }
 
-SRC_STATE *
+LIBSAMPLERATE_DLL_PRIVATE SRC_STATE *
 sinc_state_new (int converter_type, int channels, SRC_ERROR *error)
 {
 	assert (converter_type == SRC_SINC_FASTEST ||

--- a/src/src_zoh.c
+++ b/src/src_zoh.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2002-2016, Erik de Castro Lopo <erikd@mega-nerd.com>
+** Copyright (c) 2002-2021, Erik de Castro Lopo <erikd@mega-nerd.com>
 ** All rights reserved.
 **
 ** This code is released under 2-clause BSD license. Please see the
@@ -144,7 +144,7 @@ zoh_vari_process (SRC_STATE *state, SRC_DATA *data)
 /*------------------------------------------------------------------------------
 */
 
-const char*
+LIBSAMPLERATE_DLL_PRIVATE const char*
 zoh_get_name (int src_enum)
 {
 	if (src_enum == SRC_ZERO_ORDER_HOLD)
@@ -153,7 +153,7 @@ zoh_get_name (int src_enum)
 	return NULL ;
 } /* zoh_get_name */
 
-const char*
+LIBSAMPLERATE_DLL_PRIVATE const char*
 zoh_get_description (int src_enum)
 {
 	if (src_enum == SRC_ZERO_ORDER_HOLD)
@@ -182,7 +182,7 @@ zoh_data_new (int channels)
 	return priv ;
 }
 
-SRC_STATE *
+LIBSAMPLERATE_DLL_PRIVATE SRC_STATE *
 zoh_state_new (int channels, SRC_ERROR *error)
 {
 	assert (channels > 0) ;


### PR DESCRIPTION
@evpobr @sezero 
My diff, which I tested on macOS:

```
--- before
+++ after
@@ -1,9 +1,3 @@
-0000000000008d00 T _linear_get_description
-0000000000008ce0 T _linear_get_name
-0000000000008d20 T _linear_state_new
-0000000000004eb0 T _sinc_get_description
-0000000000004e90 T _sinc_get_name
-0000000000004ed0 T _sinc_state_new
 0000000000004140 T _src_callback_new
 00000000000044b0 T _src_callback_read
 00000000000040f0 T _src_clone
@@ -24,6 +18,3 @@
 0000000000004b10 T _src_short_to_float_array
 00000000000048f0 T _src_simple
 00000000000048d0 T _src_strerror
-0000000000007a90 T _zoh_get_description
-0000000000007a70 T _zoh_get_name
-0000000000007ab0 T _zoh_state_new
```