### PR TITLE
Check GNU linker instead of gcc compiler for exported symbols control.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 Unreleased
   * Switch to GCC's visibility for hiding more implementation details
+  * Check GNU ld instead of gcc for exported symbols control logic in
+    configure.ac
 
 Version 0.2.1 (2021-01-23)
   * Fix incorrect passing of -version-info to libtool, causing a

--- a/configure.ac
+++ b/configure.ac
@@ -260,14 +260,13 @@ AS_IF([test "x$enable_werror" = "xyes"], [
 AX_APPEND_COMPILE_FLAGS([-W -Wstrict-prototypes -Wmissing-prototypes -Wall -Waggregate-return -Wcast-align -Wcast-qual -Wnested-externs -Wshadow -Wpointer-arith], [CFLAGS])
 
 dnl ====================================================================================
-dnl  GCC stuff.
+dnl  Exported symbols control.
 
-AS_IF([test "x$ax_cv_c_compiler_vendor" = "xgnu"], [
-		# OS specific tweaks.
+AS_IF([test "x$lt_cv_prog_gnu_ld" = "xyes"], [
 		AS_CASE([${host_os}],
 			[mingw*|cygwin*], [
 				SHLIB_VERSION_ARG="-export-symbols \$(top_srcdir)/Win32/libsamplerate-0.def"],
-			[linux*|kfreebsd*-gnu*|gnu*], [
+			[*], [
 				SHLIB_VERSION_ARG="-Wl,--version-script=\$(top_builddir)/src/Version_script"
 			])
 	])


### PR DESCRIPTION
Also enable unix OSs other than linux, kfreebsd and hurd.  macos isn't
affected because it doesn't use GNU ld.

CMake would need something similar, i.e. compiler id -> linker id check,
but I don't know cmake enough to do that.

Closes: #149
