### PR TITLE
check visibility attributes support in configury and cmake

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -54,6 +54,10 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H
 
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#cmakedefine01 HAVE_VISIBILITY
+
 /* define fast samplerate convertor */
 #cmakedefine ENABLE_SINC_FAST_CONVERTER
 

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,8 @@ AX_APPEND_COMPILE_FLAGS([-W -Wstrict-prototypes -Wmissing-prototypes -Wall -Wagg
 dnl ====================================================================================
 dnl  Exported symbols control.
 
+gl_VISIBILITY
+
 AS_IF([test "x$lt_cv_prog_gnu_ld" = "xyes"], [
 		AS_CASE([${host_os}],
 			[mingw*|cygwin*], [

--- a/m4/visibility.m4
+++ b/m4/visibility.m4
@@ -1,0 +1,78 @@
+# visibility.m4 serial 7
+dnl Copyright (C) 2005, 2008, 2010-2021 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Bruno Haible.
+
+dnl Tests whether the compiler supports the command-line option
+dnl -fvisibility=hidden and the function and variable attributes
+dnl __attribute__((__visibility__("hidden"))) and
+dnl __attribute__((__visibility__("default"))).
+dnl Does *not* test for __visibility__("protected") - which has tricky
+dnl semantics (see the 'vismain' test in glibc) and does not exist e.g. on
+dnl Mac OS X.
+dnl Does *not* test for __visibility__("internal") - which has processor
+dnl dependent semantics.
+dnl Does *not* test for #pragma GCC visibility push(hidden) - which is
+dnl "really only recommended for legacy code".
+dnl Set the variable CFLAG_VISIBILITY.
+dnl Defines and sets the variable HAVE_VISIBILITY.
+
+AC_DEFUN([gl_VISIBILITY],
+[
+  AC_REQUIRE([AC_PROG_CC])
+  CFLAG_VISIBILITY=
+  HAVE_VISIBILITY=0
+  if test -n "$GCC"; then
+    dnl First, check whether -Werror can be added to the command line, or
+    dnl whether it leads to an error because of some other option that the
+    dnl user has put into $CC $CFLAGS $CPPFLAGS.
+    AC_CACHE_CHECK([whether the -Werror option is usable],
+      [gl_cv_cc_vis_werror],
+      [gl_save_CFLAGS="$CFLAGS"
+       CFLAGS="$CFLAGS -Werror"
+       AC_COMPILE_IFELSE(
+         [AC_LANG_PROGRAM([[]], [[]])],
+         [gl_cv_cc_vis_werror=yes],
+         [gl_cv_cc_vis_werror=no])
+       CFLAGS="$gl_save_CFLAGS"
+      ])
+    dnl Now check whether visibility declarations are supported.
+    AC_CACHE_CHECK([for simple visibility declarations],
+      [gl_cv_cc_visibility],
+      [gl_save_CFLAGS="$CFLAGS"
+       CFLAGS="$CFLAGS -fvisibility=hidden"
+       dnl We use the option -Werror and a function dummyfunc, because on some
+       dnl platforms (Cygwin 1.7) the use of -fvisibility triggers a warning
+       dnl "visibility attribute not supported in this configuration; ignored"
+       dnl at the first function definition in every compilation unit, and we
+       dnl don't want to use the option in this case.
+       if test $gl_cv_cc_vis_werror = yes; then
+         CFLAGS="$CFLAGS -Werror"
+       fi
+       AC_COMPILE_IFELSE(
+         [AC_LANG_PROGRAM(
+            [[extern __attribute__((__visibility__("hidden"))) int hiddenvar;
+              extern __attribute__((__visibility__("default"))) int exportedvar;
+              extern __attribute__((__visibility__("hidden"))) int hiddenfunc (void);
+              extern __attribute__((__visibility__("default"))) int exportedfunc (void);
+              void dummyfunc (void);
+              void dummyfunc (void) {}
+            ]],
+            [[]])],
+         [gl_cv_cc_visibility=yes],
+         [gl_cv_cc_visibility=no])
+       CFLAGS="$gl_save_CFLAGS"
+      ])
+    if test $gl_cv_cc_visibility = yes; then
+      CFLAG_VISIBILITY="-fvisibility=hidden"
+      HAVE_VISIBILITY=1
+    fi
+  fi
+  AC_SUBST([CFLAG_VISIBILITY])
+  AC_SUBST([HAVE_VISIBILITY])
+  AC_DEFINE_UNQUOTED([HAVE_VISIBILITY], [$HAVE_VISIBILITY],
+    [Define to 1 or 0, depending whether the compiler supports simple visibility declarations.])
+])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,11 +10,20 @@ set(ENABLE_SINC_FAST_CONVERTER ${LIBSAMPLERATE_ENABLE_SINC_FAST_CONVERTER} PAREN
 set(ENABLE_SINC_MEDIUM_CONVERTER ${LIBSAMPLERATE_ENABLE_SINC_MEDIUM_CONVERTER} PARENT_SCOPE)
 set(ENABLE_SINC_BEST_CONVERTER ${LIBSAMPLERATE_ENABLE_SINC_BEST_CONVERTER} PARENT_SCOPE)
 
+include(CMakePushCheckState)
+include(CheckCSourceCompiles)
 include(ClipMode)
 include(CMakePackageConfigHelpers)
 
 # This will set CPU_CLIPS_NEGATIVE and CPU_CLIPS_POSITIVE
 clip_mode()
+
+# check for symbol visibility attributes support
+cmake_push_check_state()
+set(CMAKE_REQUIRED_FLAGS "-fvisibility=hidden -Werror")
+check_c_source_compiles("int foo(void) __attribute__((visibility(\"default\")));
+                         int main(void) {return 0;}" HAVE_VISIBILITY)
+cmake_pop_check_state()
 
 add_library(samplerate
   common.h

--- a/src/common.h
+++ b/src/common.h
@@ -16,16 +16,12 @@
 
 #include <math.h>
 
-#if defined (_WIN32) || defined (__CYGWIN__) || defined (__MORPHOS__)
-  #define LIBSAMPLERATE_DLL_PRIVATE
+#if HAVE_VISIBILITY
+  #define LIBSAMPLERATE_DLL_PRIVATE __attribute__ ((visibility ("hidden")))
+#elif defined (__APPLE__)
+  #define LIBSAMPLERATE_DLL_PRIVATE __private_extern__
 #else
-  #if __GNUC__ >= 4 /* also works for Clang */
-    #define LIBSAMPLERATE_DLL_PRIVATE __attribute__ ((visibility ("hidden")))
-  #elif defined (__APPLE__)
-    #define LIBSAMPLERATE_DLL_PRIVATE __private_extern__
-  #else
-    #define LIBSAMPLERATE_DLL_PRIVATE
-  #endif
+  #define LIBSAMPLERATE_DLL_PRIVATE
 #endif
 
 #define	SRC_MAX_RATIO			256


### PR DESCRIPTION
This adds checks for visibility attributes support to configury and cmake.
CMake side is a simple addition of a few lines.  The configury (autotools)
side relies on visibility.m4 taken from gnulib, which recently got a fix
for -Wmissing-prototypes:
http://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commit;h=802931d3728acb52763c13e2644c06ad2ce0cc3f
