### PR TITLE
Add missing includes of stdbool.h

### DIFF
--- a/src/src_linear.c
+++ b/src/src_linear.c
@@ -11,6 +11,7 @@
 #endif
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/src_zoh.c
+++ b/src/src_zoh.c
@@ -11,6 +11,7 @@
 #endif
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Since 4ff9f4afdaa258 compilation failed due to "true" and "false" being undeclared:

```
% cmake .
...

% make
Consolidate compiler generated dependencies of target samplerate
[  1%] Building C object src/CMakeFiles/samplerate.dir/src_linear.c.o
/Users/yairchu/dev/soundradix/AutoAlignPost/SoundRadixLib/External/libsamplerate/src/src_linear.c:35:2: error: unknown type name 'bool'
        bool    dirty ;
        ^
/Users/yairchu/dev/soundradix/AutoAlignPost/SoundRadixLib/External/libsamplerate/src/src_linear.c:71:17: error: use of undeclared identifier 'true'
                priv->dirty = true ;
                              ^
/Users/yairchu/dev/soundradix/AutoAlignPost/SoundRadixLib/External/libsamplerate/src/src_linear.c:240:16: error: use of undeclared identifier 'false'
        priv->dirty = false ;
                      ^
3 errors generated.
make[2]: *** [src/CMakeFiles/samplerate.dir/src_linear.c.o] Error 1
make[1]: *** [src/CMakeFiles/samplerate.dir/all] Error 2
make: *** [all] Error 2
```

(on macOS 11.4 on an M1 Macbook Pro)