### PR TITLE
Switch release tarballs `.bz2` -> `.xz`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ Octave/make_src_filter
 Win32/Makefile.mingw
 aclocal.m4
 autom4te.cache
-libsamplerate-*.tar.bz2
+libsamplerate-*.tar.xz
 compile
 config.*
 !/config.h.in

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ Unreleased
     platforms.
   * Fixes and improvements for CMake build system.
   * Fixes and improvements for Autotools build system.
+  * Switch to .xz over .bz2 for release tarballs.
   * Minor bug fixes and updates.
 
 Version 0.2.1 (2021-01-23)

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([src/config.h])
 
-AM_INIT_AUTOMAKE([1.14 foreign dist-bzip2 no-dist-gzip subdir-objects serial-tests])
+AM_INIT_AUTOMAKE([1.14 foreign dist-xz no-dist-gzip subdir-objects serial-tests])
 AM_SILENT_RULES([yes])
 
 dnl ====================================================================================


### PR DESCRIPTION
* `.bz2` = 3.57 MiB
* `.xz` = 3.18 MiB
  by switching, we save over 10%