### PR TITLE
Remove reference to docs in Win32 dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ libsamplerate (also known as Secret Rabbit Code) is a library for performing sam
 * The [`docs/`](https://github.com/libsndfile/libsamplerate/tree/master/docs) directory contains the libsamplerate documentation.
 * The [`examples/`](https://github.com/libsndfile/libsamplerate/tree/master/examples) directory contains examples of how to write code using libsamplerate.
 * The [`tests/`](https://github.com/libsndfile/libsamplerate/tree/master/tests) directory contains programs which link against libsamplerate and test its functionality.
-* The [`Win32/`](https://github.com/libsndfile/libsamplerate/tree/master/Win32) directory contains files and documentation to allow libsamplerate to compile under Win32 with the Microsoft Visual C++ compiler.
+* The [`Win32/`](https://github.com/libsndfile/libsamplerate/tree/master/Win32) directory contains files to allow libsamplerate to compile under Win32 with the Microsoft Visual C++ compiler.
 
 Additional references:
 


### PR DESCRIPTION
Looks like there were moved in https://github.com/libsndfile/libsamplerate/commit/260c3f640f3aacc653ad28bd28339e4e3f5fe4e7