### PR TITLE
mac: fix build error due to deprecated kAudioObjectPropertyElementMaster

### DIFF
--- a/examples/audio_out.c
+++ b/examples/audio_out.c
@@ -438,7 +438,11 @@ opensoundsys_close (AUDIO_OUT *audio_out)
 
 #if (defined (__MACH__) && defined (__APPLE__)) /* MacOSX */
 
+#include <AvailabilityMacros.h>
 #include <CoreAudio/AudioHardware.h>
+#ifndef MAC_OS_VERSION_12_0
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
 
 #define	MACOSX_MAGIC	MAKE_MAGIC ('M', 'a', 'c', ' ', 'O', 'S', ' ', 'X')
 
@@ -493,7 +497,7 @@ macosx_open (int channels, int samplerate)
 	/*  get the default output device for the HAL */
 	propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
 	propertyAddress.mScope = kAudioDevicePropertyScopeOutput;
-	propertyAddress.mElement = kAudioObjectPropertyElementMaster;
+	propertyAddress.mElement = kAudioObjectPropertyElementMain;
 
 	count = sizeof (AudioDeviceID) ;
 	if ((err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, NULL,

--- a/tests/callback_test.c
+++ b/tests/callback_test.c
@@ -197,7 +197,7 @@ end_of_stream_test (int converter)
 	SRC_STATE	*src_state ;
 
 	double	src_ratio = 0.3 ;
-	long	read_count, read_total ;
+	long	read_count ;
 	int 	error ;
 
 	printf ("\t%-30s        ........... ", src_get_name (converter)) ;
@@ -213,12 +213,10 @@ end_of_stream_test (int converter)
 		exit (1) ;
 		} ;
 
-	read_total = 0 ;
 	do
 	{	/* We will be throwing away output data, so just grab as much as possible. */
 		read_count = ARRAY_LEN (output) / test_callback_data.channels ;
 		read_count = src_callback_read (src_state, src_ratio, read_count, output) ;
-		read_total += read_count ;
 		}
 	while (read_count > 0) ;
 


### PR DESCRIPTION
Also fixes tests build error due to `-Wunused-but-set-variable`