### PR TITLE
use sse2 intrinsics for lrint/lrintf only on windows x64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ endif()
 
 check_include_file(stdbool.h HAVE_STDBOOL_H)
 check_include_file(unistd.h HAVE_UNISTD_H)
-check_include_file (immintrin.h HAVE_IMMINTRIN_H)
 
 # For examples and tests
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -33,9 +33,6 @@
 /* Define if you have C99's lrintf function. */
 #cmakedefine01 HAVE_LRINTF
 
-/* Define to 1 if you have the <immintrin.h> header file. */
-#cmakedefine01 HAVE_IMMINTRIN_H
-
 /* Define if you have signal SIGALRM. */
 #cmakedefine01 HAVE_SIGALRM
 

--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ m4_define([abi_version_patch], [lt_revision])
 
 dnl ====================================================================================
 
-AC_CHECK_HEADERS([stdbool.h stdint.h sys/times.h unistd.h immintrin.h])
+AC_CHECK_HEADERS([stdbool.h stdint.h sys/times.h unistd.h])
 
 dnl ====================================================================================
 dnl  Couple of initializations here. Fill in real values later.

--- a/src/common.h
+++ b/src/common.h
@@ -14,7 +14,7 @@
 #include <stdbool.h>
 #endif
 
-#if HAVE_IMMINTRIN_H
+#if defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
 #include <immintrin.h>
 #endif
 
@@ -172,7 +172,7 @@ SRC_STATE *zoh_state_new (int channels, SRC_ERROR *error) ;
 
 static inline int psf_lrintf (float x)
 {
-	#ifdef HAVE_IMMINTRIN_H
+	#if defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
 		return _mm_cvtss_si32 (_mm_load_ss (&x)) ;
 	#else
 		return lrintf (x) ;
@@ -181,7 +181,7 @@ static inline int psf_lrintf (float x)
 
 static inline int psf_lrint (double x)
 {
-	#ifdef HAVE_IMMINTRIN_H
+	#if defined(_WIN32) && (defined(_M_X64) || defined(__x86_64__))
 		return _mm_cvtsd_si32 (_mm_load_sd (&x)) ;
 	#else
 		return lrint (x) ;


### PR DESCRIPTION
Fixes https://github.com/libsndfile/libsamplerate/issues/187
Fixes https://github.com/libsndfile/libsamplerate/pull/188
Fixes https://github.com/libsndfile/libsamplerate/issues/191

CC: @rfomin
