### PR TITLE
Fixes for quality.md and src-evaluate

### DIFF
--- a/docs/quality.md
+++ b/docs/quality.md
@@ -24,9 +24,8 @@ factors to consider:
 There are a number of sample rate converters available for downloading but I
 will limit the comparison of Secret Rabbit Code to the following:
 
-- [sndfile-resample](http://libsndfile.github.io/libsamplerate/download.html)
-  which is a program (which uses libsamplerate) from the **examples/** directory
-  of the Secret Rabbit Code source code distribution.
+- sndfile-resample which is a program (which uses libsamplerate) from the
+  [sndfile-tools](https://github.com/libsndfile/sndfile-tools) package.
 - [Resample](https://ccrma.stanford.edu/~jos/resample/) by Julius O Smiths which
   seems to have been the first high quality converter available as source code.
 - [ResampAudio](http://www.tsp.ece.mcgill.ca/MMSP/Documents/Software/AFsp/ResampAudio.html)

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -31,7 +31,7 @@ will limit the comparison of Secret Rabbit Code to the following:
 - [ResampAudio](http://www.tsp.ece.mcgill.ca/MMSP/Documents/Software/AFsp/ResampAudio.html)
   which is part of [Audio File Programs and Routines](http://www.tsp.ece.mcgill.ca/MMSP/Documents/Software/AFsp/AFsp.html)
   by Peter Kabal.
-- [SoX](http://home.sprynet.com/~cbagwell/sox.html) which is maintained by Chris
+- [SoX](https://sourceforge.net/projects/sox/) which is maintained by Chris
   Bagwell. SoX is also able to perform some low quality sample rate conversions
   but these will not be investigated.
 - [Shibatch](http://shibatch.sourceforge.net/) which seems to be a frequency

--- a/tests/src-evaluate.c
+++ b/tests/src-evaluate.c
@@ -74,9 +74,9 @@ int
 main (int argc, char *argv [])
 {	static RESAMPLE_PROG resample_progs [] =
 	{	{	"sndfile-resample",
-			"examples/sndfile-resample --version",
+			"sndfile-resample --version",
 			"libsamplerate",
-			"examples/sndfile-resample --max-speed -c 0 -to %d source.wav destination.wav",
+			"sndfile-resample --max-speed -c 0 -to %d source.wav destination.wav",
 			SF_FORMAT_WAV | SF_FORMAT_PCM_32
 			},
 		{	"sox",

--- a/tests/src-evaluate.c
+++ b/tests/src-evaluate.c
@@ -82,7 +82,7 @@ main (int argc, char *argv [])
 		{	"sox",
 			"sox -h 2>&1",
 			"sox",
-			"sox source.wav -r %d destination.wav resample 0.835",
+			"sox source.wav -r %d destination.wav",
 			SF_FORMAT_WAV | SF_FORMAT_PCM_32
 			},
 		{	"ResampAudio",


### PR DESCRIPTION
Some of the information and links in docs/quality.md appear to be outdated, and tests/src-evaluate.c needs some changes to be able to actually run current versions of the two resampling programs it currently supports.
