### PR TITLE
Add LIBSAMPLERATE_ENABLE_WARNINGS to generically enable warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Configure CMake
       if: startsWith(matrix.build-system,'cmake')
       working-directory: ${{runner.workspace}}/build
-      run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=Release ${{matrix.configure-options}}
+      run: cmake ${{github.workspace}} -DCMAKE_BUILD_TYPE=Release -DLIBSAMPLERATE_ENABLE_WERROR=ON ${{matrix.configure-options}}
 
     - name: Build CMake
       if: startsWith(matrix.build-system,'cmake')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 option(LIBSAMPLERATE_EXAMPLES "Enable to generate examples" ${IS_ROOT_PROJECT})
 option(LIBSAMPLERATE_INSTALL "Enable to add install directives" ${IS_ROOT_PROJECT})
+option(LIBSAMPLERATE_ENABLE_WERROR "Fail compile if any warning is triggered" OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -127,6 +128,31 @@ if(BUILD_TESTING)
 endif()
 
 # Examples
+
+if(MSVC)
+	set(LIBSAMPLERATE_WARNINGS /W3)
+	if(LIBSAMPLERATE_ENABLE_WERROR)
+		list(APPEND LIBSAMPLERATE_WARNINGS /WX)
+	endif()
+else()
+	include(CheckCCompilerFlag)
+	set(LIBSAMPLERATE_WARNINGS "")
+	foreach(flag -Wall -Wextra -pedantic)
+		string(REGEX REPLACE "[^a-zA-Z0-9]" "_" resultVar "SRC_${flag}_SUPPORTED")
+		check_c_compiler_flag(${flag} ${resultVar})
+		if(${resultVar})
+			list(APPEND LIBSAMPLERATE_WARNINGS ${flag})
+		endif()
+	endforeach()
+	if(LIBSAMPLERATE_ENABLE_WERROR)
+		check_c_compiler_flag(-Werror SRC_Werror_SUPPORTED)
+		if(SRC_Werror_SUPPORTED)
+			list(APPEND LIBSAMPLERATE_WARNINGS -Werror)
+		endif()
+	endif()
+endif()
+
+target_compile_options(samplerate PRIVATE ${LIBSAMPLERATE_WARNINGS})
 
 if(LIBSAMPLERATE_EXAMPLES)
   add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(timewarp-file
   PRIVATE
     samplerate
     $<$<BOOL:${SndFile_FOUND}>:${SNDFILE_TARGET}>)
+target_compile_options(timewarp-file PRIVATE ${LIBSAMPLERATE_WARNINGS})
 
 add_executable(varispeed-play varispeed-play.c audio_out.c audio_out.h)
 target_link_libraries(varispeed-play

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,79 +17,83 @@ endif()
 
 set(HAVE_FFTW3 ${FFTW3_FOUND} PARENT_SCOPE)
 
+add_library(samplerate_testopts INTERFACE)
+target_link_libraries(samplerate_testopts INTERFACE samplerate)
+target_compile_options(samplerate_testopts INTERFACE ${LIBSAMPLERATE_WARNINGS})
+
 add_executable(misc_test misc_test.c util.c util.h)
-target_link_libraries(misc_test PRIVATE samplerate)
+target_link_libraries(misc_test PRIVATE samplerate_testopts)
 add_test(NAME misc_test COMMAND misc_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(termination_test termination_test.c util.c util.h)
-target_link_libraries(termination_test PRIVATE samplerate)
+target_link_libraries(termination_test PRIVATE samplerate_testopts)
 add_test(NAME termination_test COMMAND termination_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(callback_hang_test callback_hang_test.c util.c util.h)
-target_link_libraries(callback_hang_test PRIVATE samplerate)
+target_link_libraries(callback_hang_test PRIVATE samplerate_testopts)
 add_test(NAME callback_hang_test COMMAND callback_hang_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(downsample_test downsample_test.c util.c util.h)
-target_link_libraries(downsample_test PRIVATE samplerate)
+target_link_libraries(downsample_test PRIVATE samplerate_testopts)
 add_test(NAME downsample_test COMMAND downsample_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(simple_test simple_test.c util.c util.h)
-target_link_libraries(simple_test PRIVATE samplerate)
+target_link_libraries(simple_test PRIVATE samplerate_testopts)
 add_test(NAME simple_test COMMAND simple_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(callback_test callback_test.c util.c util.h)
-target_link_libraries(callback_test PRIVATE samplerate)
+target_link_libraries(callback_test PRIVATE samplerate_testopts)
 add_test(NAME callback_test COMMAND callback_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(reset_test reset_test.c util.c util.h)
-target_link_libraries(reset_test PRIVATE samplerate)
+target_link_libraries(reset_test PRIVATE samplerate_testopts)
 add_test(NAME reset_test COMMAND reset_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(clone_test clone_test.c util.c util.h)
-target_link_libraries(clone_test PRIVATE samplerate)
+target_link_libraries(clone_test PRIVATE samplerate_testopts)
 add_test(NAME clone_test COMMAND clone_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(nullptr_test nullptr_test.c util.c util.h)
-target_link_libraries(nullptr_test PRIVATE samplerate)
+target_link_libraries(nullptr_test PRIVATE samplerate_testopts)
 add_test(NAME nullptr_test COMMAND nullptr_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(multi_channel_test multi_channel_test.c calc_snr.c util.c util.h)
 target_link_libraries(multi_channel_test
   PRIVATE
-    samplerate
+    samplerate_testopts
     $<$<BOOL:${FFTW3_FOUND}>:FFTW3::fftw3>
    )
 add_test(NAME multi_channel_test COMMAND multi_channel_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(varispeed_test varispeed_test.c calc_snr.c util.c util.h)
 target_link_libraries(varispeed_test
-  PRIVATE samplerate
+  PRIVATE samplerate_testopts
     $<$<BOOL:${FFTW3_FOUND}>:FFTW3::fftw3>
    )
 add_test(NAME varispeed_test COMMAND varispeed_test util.c util.h WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(float_short_test float_short_test.c)
-target_link_libraries(float_short_test PRIVATE samplerate)
+target_link_libraries(float_short_test PRIVATE samplerate_testopts)
 add_test(NAME float_short_test COMMAND float_short_test WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(snr_bw_test snr_bw_test.c calc_snr.c util.c util.h)
 target_link_libraries(snr_bw_test
   PRIVATE
-    samplerate
+    samplerate_testopts
     $<$<BOOL:${FFTW3_FOUND}>:FFTW3::fftw3>
    )
 add_test(NAME snr_bw_test COMMAND snr_bw_test util.c util.h WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/src)
 
 add_executable(throughput_test throughput_test.c util.c util.h)
-target_link_libraries(throughput_test PRIVATE samplerate)
+target_link_libraries(throughput_test PRIVATE samplerate_testopts)
 
 add_executable(multichan_throughput_test multichan_throughput_test.c util.c util.h)
-target_link_libraries(multichan_throughput_test PRIVATE samplerate)
+target_link_libraries(multichan_throughput_test PRIVATE samplerate_testopts)
 
 add_executable(src-evaluate src-evaluate.c util.c util.h calc_snr.c)
 target_link_libraries(src-evaluate
   PRIVATE
-    samplerate
+    samplerate_testopts
     $<$<BOOL:${FFTW3_FOUND}>:FFTW3::fftw3>
     $<$<BOOL:${SndFile_FOUND}>:${SNDFILE_TARGET}>
    )


### PR DESCRIPTION
Useful for (and used in) CI

Since #82 the warnings have already been fixed. This change ensures that it stays like that.