### PR TITLE
Fix tests & examples on shared build on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [
-        linux-cmake,
-        linux-autotools,
-        macos-cmake,
-        macos-autotools,
-        windows-cmake
-        ]
         include:
           - name: linux-cmake
             os: ubuntu-latest
@@ -37,6 +30,11 @@ jobs:
             os: windows-latest
             build-system: cmake
             configure-options: -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
+
+          - name: windows-cmake-shared
+            os: windows-latest
+            build-system: cmake
+            configure-options: -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DBUILD_SHARED_LIBS=ON
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,12 @@ if(LIBSAMPLERATE_EXAMPLES OR BUILD_TESTING)
   endif()
 
   set(HAVE_SNDFILE ${SndFile_FOUND})
+
+  # Windows DLLs need to be in the same folder as the executable to be found
+  if(WIN32 AND NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+  endif()
+
 endif()
 
 # SampleRate library


### PR DESCRIPTION
On Windows DLLs are created which must be in the same folder as the executables.
Do that in the main CML and add a matching CI job