### PR TITLE
Avoid UB in overlap checks

### DIFF
--- a/src/samplerate.c
+++ b/src/samplerate.c
@@ -110,19 +110,22 @@ src_process (SRC_STATE *state, SRC_DATA *data)
 	if (data->output_frames < 0)
 		data->output_frames = 0 ;
 
-	if (data->data_in < data->data_out)
-	{	if (data->data_in + data->input_frames * state->channels > data->data_out)
-		{	/*-printf ("\n\ndata_in: %p    data_out: %p\n",
-				(void*) (data->data_in + data->input_frames * psrc->channels), (void*) data->data_out) ;-*/
+	if(data->data_in && data->data_out)
+	{
+		if (data->data_in < data->data_out)
+		{	if (data->data_in + data->input_frames * state->channels > data->data_out)
+			{	/*-printf ("\n\ndata_in: %p    data_out: %p\n",
+					(void*) (data->data_in + data->input_frames * psrc->channels), (void*) data->data_out) ;-*/
+				return SRC_ERR_DATA_OVERLAP ;
+				} ;
+			}
+		else if (data->data_out + data->output_frames * state->channels > data->data_in)
+		{	/*-printf ("\n\ndata_in : %p   ouput frames: %ld    data_out: %p\n", (void*) data->data_in, data->output_frames, (void*) data->data_out) ;
+
+			printf ("data_out: %p (%p)    data_in: %p\n", (void*) data->data_out,
+				(void*) (data->data_out + data->input_frames * psrc->channels), (void*) data->data_in) ;-*/
 			return SRC_ERR_DATA_OVERLAP ;
 			} ;
-		}
-	else if (data->data_out + data->output_frames * state->channels > data->data_in)
-	{	/*-printf ("\n\ndata_in : %p   ouput frames: %ld    data_out: %p\n", (void*) data->data_in, data->output_frames, (void*) data->data_out) ;
-
-		printf ("data_out: %p (%p)    data_in: %p\n", (void*) data->data_out,
-			(void*) (data->data_out + data->input_frames * psrc->channels), (void*) data->data_in) ;-*/
-		return SRC_ERR_DATA_OVERLAP ;
 		} ;
 
 	/* Set the input and output counts to zero. */


### PR DESCRIPTION
Doing pointer arithmetic on a NULL pointer is undefined behavior. This got flagged in a run using UBSAN.
Disable the checks if any of the data pointers is NULL.