### PR TITLE
Double precision interface for the caller to calculate frames consumed while using the callback API

### DIFF
--- a/include/samplerate.h
+++ b/include/samplerate.h
@@ -71,6 +71,14 @@ SRC_STATE* src_clone (SRC_STATE* orig, int *error) ;
 SRC_STATE* src_callback_new (src_callback_t func, int converter_type, int channels,
 				int *error, void* cb_data) ;
 
+
+/**
+ * Double-precision getters: Fractional used-frame 
+ * tracking while using the callback API. 
+ */
+double src_get_last_position(SRC_STATE* state);
+double src_get_saved_frames(SRC_STATE* state);
+
 /*
 **	Cleanup all internal allocations.
 **	Always returns NULL.

--- a/src/samplerate.c
+++ b/src/samplerate.c
@@ -72,6 +72,15 @@ src_callback_new (src_callback_t func, int converter_type, int channels, int *er
 	return state ;
 } /* src_callback_new */
 
+
+double src_get_last_postion(SRC_STATE* state) {
+	return state->last_position;
+}
+
+double src_get_saved_frames(SRC_STATE* state) {
+	return state->saved_frames;
+}
+
 SRC_STATE *
 src_delete (SRC_STATE *state)
 {


### PR DESCRIPTION
Hello! I am a contributor to Mixxx (https://github.com/mixxxdj/mixxx), working as part of my GSOC 2025 project. 

I have integrated the libsamplerate API into our software (See https://github.com/mixxxdj/mixxx/pull/15005)
and have observed significant latency gains over our previous resampler. (See https://github.com/mixxxdj/mixxx/pull/15005#issuecomment-3014498917)

However, for correctness we believe double-precision tracking is necessary (not just for mixxx, but for other real-time applications as well). We would like to upstream the libsamplerate changes, but cannot do so without a double precision interface upstreamed to libsamplerate. Hence the PR.

Thank you!