### PR TITLE
cmake: remove unused macros from config.h template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 test_big_endian(CPU_IS_BIG_ENDIAN)
-if(CPU_IS_BIG_ENDIAN)
-  set(CPU_IS_LITTLE_ENDIAN 0)
-else()
-  set(CPU_IS_LITTLE_ENDIAN 1)
-endif()
 
 check_include_file(stdbool.h HAVE_STDBOOL_H)
 check_include_file(unistd.h HAVE_UNISTD_H)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -15,9 +15,6 @@
 /* Target processor is big endian. */
 #cmakedefine01 CPU_IS_BIG_ENDIAN
 
-/* Target processor is little endian. */
-#cmakedefine01 CPU_IS_LITTLE_ENDIAN
-
 /* Define to 1 if you have the `alarm' function. */
 #cmakedefine01 HAVE_ALARM
 
@@ -26,12 +23,6 @@
 
 /* Set to 1 if you have libfftw3. */
 #cmakedefine01 HAVE_FFTW3
-
-/* Define if you have C99's lrint function. */
-#cmakedefine01 HAVE_LRINT
-
-/* Define if you have C99's lrintf function. */
-#cmakedefine01 HAVE_LRINTF
 
 /* Define to 1 if you have the <immintrin.h> header file. */
 #cmakedefine HAVE_IMMINTRIN_H
@@ -47,9 +38,6 @@
 
 /* Define to 1 if you have the <stdbool.h> header file. */
 #cmakedefine HAVE_STDBOOL_H
-
-/* Define to 1 if you have the <stdint.h> header file. */
-#cmakedefine01 HAVE_STDINT_H
 
 /* Define to 1 if you have the <sys/times.h> header file. */
 #cmakedefine01 HAVE_SYS_TIMES_H
@@ -69,8 +57,3 @@
 /* define best samplerate convertor */
 #cmakedefine ENABLE_SINC_BEST_CONVERTER
 
-/* The size of `int', as computed by sizeof. */
-#define SIZEOF_INT ${SIZEOF_INT}
-
-/* The size of `long', as computed by sizeof. */
-#define SIZEOF_LONG ${SIZEOF_LONG}


### PR DESCRIPTION
## Summary

Six macros defined in `config.h.cmake` are never referenced in any C or header file in the library:

- `CPU_IS_LITTLE_ENDIAN`
- `HAVE_LRINT`
- `HAVE_LRINTF`
- `HAVE_STDINT_H`
- `SIZEOF_INT`
- `SIZEOF_LONG`

These appear to be remnants from when libsamplerate provided its own `lrint`/`lrintf` fallbacks and portability shims for older compilers. That code was removed, but the corresponding `config.h` entries were not.

The `if(CPU_IS_BIG_ENDIAN)/set(CPU_IS_LITTLE_ENDIAN)` block in `CMakeLists.txt` is also removed, as it existed solely to populate the now-removed `CPU_IS_LITTLE_ENDIAN` entry.

## Verification

Grepped all `.c` and `.h` files under `src/` and `include/` — none of the six symbols appear anywhere.

```
$ grep -r "CPU_IS_LITTLE_ENDIAN\|HAVE_LRINT\|HAVE_LRINTF\|HAVE_STDINT_H\|SIZEOF_INT\|SIZEOF_LONG" src/ include/
(no output)
```

Spotted while using libsamplerate as a vendored CMake submodule in an Android project; the Android Studio C/C++ unused-macro inspection flagged these in the generated `config.h`.