### PR TITLE
WIP: Use NEON intrinsics for lrint on arm64 processors

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -36,6 +36,10 @@
 #   endif
 #endif
 
+#if defined(__aarch64__) || defined(_M_ARM64)
+#	define HAVE_NEON_INTRINSICS
+#endif
+
 #ifdef HAVE_SSE2_INTRINSICS
 #ifdef HAVE_IMMINTRIN_H
 #include <immintrin.h>
@@ -43,6 +47,10 @@
 #include <emmintrin.h>
 #endif
 #endif /* HAVE_SSE2_INTRINSICS */
+
+#if defined(HAVE_NEON_INTRINSICS)
+#include <arm_neon.h>
+#endif /* HAVE_NEON_INTRINSICS */
 
 #include <math.h>
 
@@ -213,6 +221,18 @@ psf_lrint (double x)
 {
 	return _mm_cvtsd_si32 (_mm_load_sd (&x)) ;
 }
+
+#elif defined(HAVE_NEON_INTRINSICS)
+
+static inline int psf_lrintf (float x)
+{
+	return vcvts_s32_f32(x);
+} /* psf_lrintf */
+
+static inline int psf_lrint (double x)
+{
+	return (int) vcvtd_s64_f64(x);
+} /* psf_lrint */
 
 #else
 


### PR DESCRIPTION
The performance of the library can be improved on arm64 processors by using NEON intrinsics for the lrint() and lrintf() functions, like previously done on x86_64 with SSE2.
