### PR TITLE
Fix `cmake_minimum_required` version range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16..3.20)
+cmake_minimum_required(VERSION 3.16...3.20)
 
 project(libsamplerate VERSION 0.2.2 LANGUAGES C)
 


### PR DESCRIPTION
It needs 3 dots not only 2